### PR TITLE
upcase the department name in the last question

### DIFF
--- a/SQL Deep Dive/Group By/questions.sql
+++ b/SQL Deep Dive/Group By/questions.sql
@@ -17,7 +17,7 @@ FROM employees as e
 
 
 /*
-*  Show me all the employees that work in the department development
+*  Show me all the employees that work in the department Development
 *  Database: Employees
 */
 


### PR DESCRIPTION
The department name is `Development`
With lowercase `development` result comes out empty (unless dept_no look up is done outside and hardcoded into the query - like in the solution)