### PR TITLE
question: Fix Typo In Distinct Starter SQL Query

### DIFF
--- a/SQL Deep Dive/Distinct/questions.sql
+++ b/SQL Deep Dive/Distinct/questions.sql
@@ -4,7 +4,7 @@
 * Question: What unique titles do we have?
 */
 
-SELECT * FROM employees;
+SELECT * FROM titles;
 
 
 /*


### PR DESCRIPTION
A wrong table was used in the starter SQL query for the first
exercise testing one's knowledge using the "Distinct" key word.

Replace the table name employee with the table name titles.