### PR TITLE
Update Comparison Operator questions to match answers given

### DIFF
--- a/SQL Deep Dive/Comparison Operators/answers.sql
+++ b/SQL Deep Dive/Comparison Operators/answers.sql
@@ -4,20 +4,20 @@ SELECT COUNT(firstName)
 FROM customers
 WHERE gender = 'F' and state = 'OR';
 
--- Who over the age of 44 has an income of 100 000 or more? (excluding 44)
+-- How many customers over the age of 44 have an income of 100 000 or more? (excluding 44)?
 -- Result: 2497
 SELECT COUNT(income)
 FROM customers
 WHERE age > 44 and income >= 100000;
 
--- Who between the ages of 30 and 50 has an income less than 50 000?
+-- How many customers between the ages of 30 and 50 have an income less than 50 000?
 -- (include 30 and 50 in the results)
 -- Result: 2362
 SELECT COUNT(income)
 FROM customers
 WHERE age >= 30 and age <= 50 AND income < 50000;
 
--- What is the average income between the ages of 20 and 50? (Excluding 20 and 50)
+-- What is the average income of customers between the ages of 20 and 50? (Excluding 20 and 50)?
 -- Result: 59409.926240780098
 SELECT AVG(income)
 FROM customers

--- a/SQL Deep Dive/Comparison Operators/answers.sql
+++ b/SQL Deep Dive/Comparison Operators/answers.sql
@@ -4,7 +4,7 @@ SELECT COUNT(firstName)
 FROM customers
 WHERE gender = 'F' and state = 'OR';
 
--- How many customers over the age of 44 have an income of 100 000 or more? (excluding 44)?
+-- How many customers over the age of 44 have an income of 100 000 or more? (excluding 44)
 -- Result: 2497
 SELECT COUNT(income)
 FROM customers
@@ -17,7 +17,7 @@ SELECT COUNT(income)
 FROM customers
 WHERE age >= 30 and age <= 50 AND income < 50000;
 
--- What is the average income of customers between the ages of 20 and 50? (Excluding 20 and 50)?
+-- What is the average income of customers between the ages of 20 and 50? (Excluding 20 and 50)
 -- Result: 59409.926240780098
 SELECT AVG(income)
 FROM customers

--- a/SQL Deep Dive/Comparison Operators/questions.sql
+++ b/SQL Deep Dive/Comparison Operators/questions.sql
@@ -1,21 +1,23 @@
+-- Using the Store Database
+-- and the customer table,
+
 -- How many female customers do we have from the state of Oregon (OR)?
 /*
 * Write your query here
 */
 
--- Who over the age of 44 has an income of 100 000 or more? (excluding 44)
+-- How many customers over the age of 44 have an income of 100 000 or more? (excluding 44)
 /*
 * Write your query here
 */
 
--- Who between the ages of 30 and 50 has an income less than 50 000?
+-- How many customers between the ages of 30 and 50 have an income less than 50 000?
 -- (include 30 and 50 in the results)
-
 /*
 * Write your query here
 */
 
--- What is the average income between the ages of 20 and 50? (Excluding 20 and 50)
+-- What is the average income of customers between the ages of 20 and 50? (Excluding 20 and 50)
 /*
 * Write your query here
 */


### PR DESCRIPTION
I made the language of the questions match exactly the actual answers given.  For example, question 2 asks, "Who over the age of 44 has an income of 100 000 or more? (excluding 44)", which implies to me that the answer should be a list of the first and last names of the resulting customers.  The answer actually gives the total number of resulting customers.

I updated question 2 to "<s>Who</s> <u>How many customers</u> over the age of 44 <s>has</s> <u>have</u> an income of 100 000 or more? (excluding 44)" to make it clear that the COUNT of those customers is being requested.

Changes made:
1. Update questions.
2. Replace the questions re-written in the answer file with the updated questions.
3. Add, then remove unnecessary question marks in the answer file.
4. Add the names of the database and table above the questions as that was implied in the Reminders section of the Exercise.